### PR TITLE
ZO-5449: avoid deprecated `commonLabels` and set labels explicitly

### DIFF
--- a/components/postgrest/deployment.yaml
+++ b/components/postgrest/deployment.yaml
@@ -8,8 +8,13 @@ metadata:
     pg-services: required
     wait-for-migrations: required
 spec:
+  selector:
+    matchLabels:
+      app: postgrest
   template:
     metadata:
+      labels:
+        app: postgrest
       annotations:
         fluentbit.io/parser-postgrest: postgrest
     spec:

--- a/components/postgrest/kustomization.yaml
+++ b/components/postgrest/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-commonLabels:
-  app: postgrest
-
 resources:
 - config.yaml
 - deployment.yaml


### PR DESCRIPTION
Soll ~den Fehler~ die Warnung bzgl. der `commonLabels` fixen.