### PR TITLE
ZO-5105: Configure external-secrets in component nightwatch

### DIFF
--- a/components/nightwatch/deployment.yaml
+++ b/components/nightwatch/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         app: nightwatch
       annotations:
         fluentbit.io/parser: zon-json-iso8601
+        reloader.stakater.com/auto: "true"
     spec:
       serviceAccountName: baseproject
       containers:
@@ -48,6 +49,10 @@ spec:
           - name: nightwatch-helpers
             mountPath: /helpers
             readOnly: true
+          envFrom:
+          - secretRef:
+              name: external-secrets
+              optional: true
       volumes:
       - name: nightwatch-helpers
         configMap:


### PR DESCRIPTION
Der PR konfiguriert für das 'nightwatch' Deployment das optionale Setzen von External Secrets. Dabei muss der Name jeweils im Projekt `external-secrets` lauten. Wir können auch nach Belieben einen fixen Namen in einer anderen Geschmacksvariante wählen. Im jeweiligen Projekt, das die 'nightwatch' Komponente benutzt, können die (external) Secrets dann hinzugefügt werden, [zum Beispiel so](https://github.com/ZeitOnline/zeit.web/pull/7927/files#diff-b05124cc32ed7bffa78a42d30e2b46e7a70bd9fc87c4ac40b150a19b1e854701R6).