### PR TITLE
feat(cloudsql): add component for 'cloud-sql-proxy' sidecar

### DIFF
--- a/components/cloud-sql-proxy/cronjob.yaml
+++ b/components/cloud-sql-proxy/cronjob.yaml
@@ -1,0 +1,26 @@
+- op: add
+  path: /spec/jobTemplate/spec/template/spec/serviceAccount
+  value: baseproject
+- op: add
+  path: /spec/jobTemplate/spec/template/spec/containers/0/envFrom/-
+  value:
+    secretRef:
+      name: cloudsql-proxy-iam
+- op: add
+  path: /spec/jobTemplate/spec/template/spec/containers/-
+  value:
+    name: cloud-sql-proxy
+    command:
+    - /cloud-sql-proxy
+    - $(INSTANCE_CONNECTION)
+    - --auto-iam-authn
+    - --address=0.0.0.0
+    env:
+    - name: INSTANCE_CONNECTION
+      valueFrom:
+        secretKeyRef:
+          key: INSTANCE_CONNECTION
+          name: cloudsql-proxy-iam
+    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.2@sha256:fd2baaf9c709598e54838a6875833759412033ab5ee578cc81f9825fa34bd296
+    securityContext:
+      runAsNonRoot: true

--- a/components/cloud-sql-proxy/deployment.yaml
+++ b/components/cloud-sql-proxy/deployment.yaml
@@ -1,0 +1,26 @@
+- op: add
+  path: /spec/template/spec/serviceAccount
+  value: baseproject
+- op: add
+  path: /spec/template/spec/containers/0/envFrom/-
+  value:
+    secretRef:
+      name: cloudsql-proxy-iam
+- op: add
+  path: /spec/template/spec/containers/-
+  value:
+    name: cloud-sql-proxy
+    command:
+    - /cloud-sql-proxy
+    - $(INSTANCE_CONNECTION)
+    - --auto-iam-authn
+    - --address=0.0.0.0
+    env:
+    - name: INSTANCE_CONNECTION
+      valueFrom:
+        secretKeyRef:
+          key: INSTANCE_CONNECTION
+          name: cloudsql-proxy-iam
+    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.2@sha256:fd2baaf9c709598e54838a6875833759412033ab5ee578cc81f9825fa34bd296
+    securityContext:
+      runAsNonRoot: true

--- a/components/cloud-sql-proxy/kustomization.yaml
+++ b/components/cloud-sql-proxy/kustomization.yaml
@@ -1,0 +1,19 @@
+# this layer makes sure all database clients have a
+# 'cloud-sql-proxy' set up as a sidecar
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+- path: deployment.yaml
+  target:
+    kind: Deployment
+    labelSelector: cloud-sql-proxy=required
+- path: deployment.yaml
+  target:
+    kind: Job
+    labelSelector: cloud-sql-proxy=required
+- path: cronjob.yaml
+  target:
+    kind: CronJob
+    labelSelector: cloud-sql-proxy=required


### PR DESCRIPTION
This can be used to conveniently attach a "sidecar" running 'cloud-sql-proxy' with IAM. The required instance connection string is taken from the 'cloudsql-proxy-iam' secret. The deployment or cronjob in question needs to have a label "cloud-sql-proxy: required" for the patches to be applied:

```yaml
labels:
- pairs:
    cloud-sql-proxy: required
components:
- github.com/ZeitOnline/kustomize/components/postgrest?ref=1.20
```

Refs: https://github.com/ZeitOnline/spiele-deployment/pull/193